### PR TITLE
ci: add "type a version in a box" dispatch (rust-gem-release@0.11.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 # ============================================================================
 # phrasekit's release workflow — a thin caller of the shared reusable workflow
-# scientist-labs/rust-gem-release (pinned @0.10.0).
+# scientist-labs/rust-gem-release (pinned @0.11.0).
 #
 # It owns ONLY the bits a reusable (on: workflow_call) workflow cannot: the tag
 # trigger, the contents:write token grant, and the per-gem inputs/secrets. Every
@@ -28,6 +28,10 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+.*"
   workflow_dispatch:
     inputs:
+      version:
+        type: string
+        default: ""
+        description: "Version to cut + release, e.g. 1.0.0 (blank = build-only dry-run)"
       publish:
         type: boolean
         default: false
@@ -49,13 +53,16 @@ jobs:
     # Normal PRs skip the expensive matrix; only a `dry-run-release` label opts in.
     # Tag pushes and manual dispatch always run.
     if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'dry-run-release') }}
-    uses: scientist-labs/rust-gem-release/.github/workflows/release.yml@0.10.0
+    uses: scientist-labs/rust-gem-release/.github/workflows/release.yml@0.11.0
     with:
       # gem-name == ext-name == gemspec basename == "phrasekit", so ext-name, gemspec,
       # and platform-gem-env (RUST_GEM_PLATFORM, the default) all default-resolve and
       # are omitted.
       gem-name: phrasekit
       version-command: ruby -r./lib/phrasekit/version -e 'print PhraseKit::VERSION'
+      version: ${{ inputs.version }}
+      bump-command: |
+        sed -i 's/^\( *VERSION *= *\).*/\1"'"$VERSION"'"/' lib/phrasekit/version.rb
       # Publish only on tag push, or on a manual dispatch that explicitly opts in.
       # Every PR (dry-run-release matrix) stays publish=false.
       publish: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish) }}


### PR DESCRIPTION
Adopts **rust-gem-release@0.11.0** and adds the new **"type a version in a box"** release path.

**Surgical change** to the existing thin caller:
- bump the reusable-workflow pin `@0.10.0` → `@0.11.0`
- add an optional `version` input to `workflow_dispatch`
- pass `version` + a `bump-command` (sed on `lib/phrasekit/version.rb`) through to the shared workflow

Now releasable three ways: **CLI** (`git tag X && git push --tags`), **version box** (Actions → Run workflow → type a version + check publish), and a **version-less dry-run**. The tag-push path and the `dry-run-release` PR path are **byte-identical** to before.

⚠️ This PR does **not** bump the gem version — release with the agreed bump policy (precompiled gems: minor; CI-only: patch) via the box or a tag.

Note: Not yet published to RubyGems; first publish will create the gem.

Companion to the merged rust-gem-release feature (bump-on-dispatch).